### PR TITLE
Add check for data URLs

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -46,7 +46,7 @@ export default class MetadataIcon extends Plugin {
 	}
 
 	getResourcePath(path: string): string {
-		if (/https?:\/\//.test(path)) {
+		if (/^(https?:\/\/|data:)/.test(path)) {
 			return path;
 		}
 		const adapter = this.app.vault.adapter;


### PR DESCRIPTION
Last update broke something that was working just fine before: Using data URLs for icons. Instead of linking to external resources, you could use a self-contained URL. (Lucide icons website includes a generator for such data URLs).

This PR includes a simple change to check for that kind of URL. It's tested and I'm already using it in my vault.

Thanks for the plugin!